### PR TITLE
merge: specify version tag for maven instead of the bad practice 'latest'

### DIFF
--- a/java-app-v2/Dockerfile.alpine
+++ b/java-app-v2/Dockerfile.alpine
@@ -1,7 +1,7 @@
 #
 # Build the app using maven in a container
 #
-FROM maven:latest AS devenv
+FROM maven:3.6-jdk-8-alpine AS devenv
 WORKDIR /usr/src/java-app 
 COPY app/pom.xml .
 RUN mvn -B -f pom.xml -s /usr/share/maven/ref/settings-docker.xml dependency:resolve


### PR DESCRIPTION
`maven:latest` is bad practice. use alpine tag of maven image that matches the JRE version of the destination build artifact image (i.e tomcat)